### PR TITLE
updated appveyor.yml config

### DIFF
--- a/JenkinsWebApi.sln
+++ b/JenkinsWebApi.sln
@@ -3,11 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "JenkinsWebApiDoc", "JenkinsWebApiDoc\JenkinsWebApiDoc.shfbproj", "{E5B1175A-CC6F-4899-8496-9412C872F3CA}"
-	ProjectSection(ProjectDependencies) = postProject
-		{BE64FA67-2D2E-4405-BE62-168159B2640E} = {BE64FA67-2D2E-4405-BE62-168159B2640E}
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JenkinsTest", "JenkinsTest\JenkinsTest.csproj", "{2229B804-CF79-4426-8AAF-DE086406DE3B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Generator", "Generator\Generator.csproj", "{15C4CA4F-748A-4934-B0E3-49A5009E9C96}"
@@ -23,6 +18,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JenkinsWebApiCore", "JenkinsWebApiCore\JenkinsWebApiCore.csproj", "{A9E094E5-5F84-4FD0-BA56-11A321E0937D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JenkinsWebApiStd", "JenkinsWebApiStd\JenkinsWebApiStd.csproj", "{7DB0CF9C-8D6B-456F-8FC8-32BC9C35339F}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "JenkinsWebApiDoc", "JenkinsWebApiDoc\JenkinsWebApiDoc.shfbproj", "{E5B1175A-CC6F-4899-8496-9412C872F3CA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{BE64FA67-2D2E-4405-BE62-168159B2640E} = {BE64FA67-2D2E-4405-BE62-168159B2640E}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution

--- a/JenkinsWebApi/JenkinsWebApi.csproj
+++ b/JenkinsWebApi/JenkinsWebApi.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\JenkinsWebApi.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HtmlAgilityPack, Version=1.11.4.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\packages\HtmlAgilityPack.1.11.4\lib\Net45\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.11.16.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.11.16\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/JenkinsWebApi/packages.config
+++ b/JenkinsWebApi/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HtmlAgilityPack" version="1.11.4" targetFramework="net45" />
+  <package id="HtmlAgilityPack" version="1.11.16" targetFramework="net45" />
 </packages>

--- a/JenkinsWebApiUwp/JenkinsWebApiUwp.csproj
+++ b/JenkinsWebApiUwp/JenkinsWebApiUwp.csproj
@@ -128,7 +128,7 @@
       <Version>1.5.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.7</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\JenkinsWebApiShared\JenkinsWebApiShared.projitems" Label="Shared" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,6 @@
-version: 1.0.{build}
+version: 2.0.{build}
 image: Visual Studio 2017
 
-
-environment:
-  matrix:
-    #- PlatformToolset: v140
-    - PlatformToolset: v141
 
 platform:
     - Any CPU
@@ -17,18 +12,39 @@ configuration:
 
 install:
     - nuget restore "%APPVEYOR_BUILD_FOLDER%"\JenkinsTest\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\packages
+    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\JenkinsWebApi\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\packages
+        
+    - ps: >-
+        Start-FileDownload 'https://github.com/EWSoftware/SHFB/releases/download/v2019.9.15.0/SHFBInstaller_v2019.9.15.0.zip'
+
+        7z x -y SHFBInstaller_v2019.9.15.0.zip | Out-Null
+
+        Write-Host "Installing MSI..."
+
+        cmd /c start /wait msiexec /i InstallResources\SandcastleHelpFileBuilder.msi /quiet
+
+        Write-Host "Installing VSIX..."
+
+        . "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VSIXInstaller.exe" /q /a InstallResources\SHFBVisualStudioPackage_VS2015AndLater.vsix
+
+        Write-Host "Sandcastle installed" -ForegroundColor Green
+
+    - set SHFBROOT=C:\Program Files (x86)\EWSoftware\Sandcastle Help File Builder\
 
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"
-    - msbuild JenkinsWebApi.sln /m /t:Generator;JenkinsWebApi;dl;JenkinsWebApiUwp;JenkinsWebApiCore;JenkinsWebApiStd;JenkinsTest /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild JenkinsWebApi.sln /m /verbosity:minimal /t:restore /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild JenkinsWebApi.sln /m /verbosity:minimal /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - cd "%APPVEYOR_BUILD_FOLDER%"\Nuget
+    - pack.cmd
 
 after_build:
     - cd "%APPVEYOR_BUILD_FOLDER%"
     - ps: >-
         Push-AppveyorArtifact "JenkinsWebApi\bin\$env:CONFIGURATION\JenkinsWebApi.dll" -FileName JenkinsWebApi.dll
 
-        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141") {
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release") {
             $ZipFileName = "JenkinsWebApi_$($env:APPVEYOR_REPO_TAG_NAME).zip"
             7z a $ZipFileName JenkinsWebApi\bin\$env:CONFIGURATION\JenkinsWebApi.dll
         }
@@ -47,5 +63,4 @@ deploy:
     force_update: true
     on:
         appveyor_repo_tag: true
-        PlatformToolset: v141
         configuration: Release


### PR DESCRIPTION
- added missing nuget restore of the new packages
- removed unused PlatformToolset
- added sandcastle build

, see https://ci.appveyor.com/project/chcg/jenkinswebapi

Build still failing due to missing file:
 
CSC : error CS2001: Source file 'C:\projects\jenkinswebapi\JenkinsTest\FuncUnitTests.cs' could not be found. [C:\projects\jenkinswebapi\JenkinsTest\JenkinsTest.csproj]

and warning of nuget package build:

C:\Program Files\dotnet\sdk\2.2.108\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(202,5): warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. [C:\projects\jenkinswebapi\JenkinsWebApiCore\JenkinsWebApiCore.csproj]

Is it intended that:
Successfully created package 'C:\projects\jenkinswebapi\JenkinsWebApiCore\bin\Release\JenkinsWebApi.2.1.0.nupkg'.
and 
Successfully created package 'C:\projects\jenkinswebapi\JenkinsWebApiStd\bin\Release\JenkinsWebApi.2.1.0.nupkg'.
are named identical?